### PR TITLE
Corrige le problème de ligne de recherche qui disparait

### DIFF
--- a/spte.js
+++ b/spte.js
@@ -23,7 +23,7 @@ let lsStickyHeader = localStorage.getItem('spteStickyHeader') === 'true';
 // Main existing elements.
 const gpContent = document.querySelector('.gp-content');
 if (gpContent) { gpContent.style.maxWidth = '85% !important'; }
-const bigTitle = document.querySelector('.gp-content .breadcrumb+h2');
+const bigTitle = document.querySelector('.gp-content > h2');
 const topPaging = document.querySelector('.gp-content .paging');
 const translations = document.querySelectorAll('tr.preview:not(.sp-has-spte-error) .translation-text');
 const bulkActions = document.querySelector('#bulk-actions-toolbar-top');
@@ -562,7 +562,7 @@ function launchProcess(spteSettings = '') {
 		displayResults();
 		manageControls();
 		buildHeader();
-		ifSourceHiddenTagTarget('.breadcrumb+h2', '#sp-main-header', 'sp-sticky');
+		ifSourceHiddenTagTarget('.gp-content > h2', '#sp-main-header', 'sp-sticky');
 		if (isConnected) {
 			observeMutations();
 		}


### PR DESCRIPTION
fix #40

Pour récupérer le titre H2 du DOM, SPTE utilise le selecteur `.gp-content .breadcrumb+h2`, sauf qu'il est possible qu’il y ait une notice entre le fil d’Ariane et le h2 (visible dans les screens de @jeherve : https://github.com/webaxones/spte/issues/40#issuecomment-820173719) Ce qui provoque le soucis.

J'ai simplifié le sélecteur pour qu’il fonctionne dans tous les cas.